### PR TITLE
Add A Conscience Plugin

### DIFF
--- a/manifests/a-conscience-plugin.yaml
+++ b/manifests/a-conscience-plugin.yaml
@@ -1,0 +1,11 @@
+name: A Conscience Plugin
+authors: Josh Mudge
+homepage: https://github.com/mathwhiz1212/ES-conscience-plugin
+license: GPL-3.0-or-later
+version: v0.1.0
+shortDescription: "You get more help from the Quarg so you don't have to drop a big bomb on Zenith, killing civilians."
+description: I may add more "conscience" adjustments in the future, but for now, you get more help from the Quarg to destroy the Korath drones. This allows you to not kill civilians on Zenith and not need to capture a Korath war fleet to accomplish that.
+url: https://github.com/mathwhiz1212/ES-conscience-plugin/archive/refs/tags/v0.1.0.zip
+autoupdate:
+  type: tag
+  url: https://github.com/mathwhiz1212/ES-conscience-plugin/archive/refs/tags/$version.zip

--- a/manifests/a-conscience-plugin.yaml
+++ b/manifests/a-conscience-plugin.yaml
@@ -2,10 +2,10 @@ name: A Conscience Plugin
 authors: Josh Mudge
 homepage: https://github.com/mathwhiz1212/ES-conscience-plugin
 license: GPL-3.0-or-later
-version: v0.1.0
+version: v0.1.1
 shortDescription: "You get more help from the Quarg so you don't have to drop a big bomb on Zenith, killing civilians."
 description: I may add more "conscience" adjustments in the future, but for now, you get more help from the Quarg to destroy the Korath drones. This allows you to not kill civilians on Zenith and not need to capture a Korath war fleet to accomplish that.
-url: https://github.com/mathwhiz1212/ES-conscience-plugin/archive/refs/tags/v0.1.0.zip
+url: https://github.com/mathwhiz1212/ES-conscience-plugin/archive/refs/tags/v0.1.1.zip
 autoupdate:
   type: tag
   url: https://github.com/mathwhiz1212/ES-conscience-plugin/archive/refs/tags/$version.zip


### PR DESCRIPTION
I didn't like bombing Zenith with a nuke-like bomb and killing civilians, and I heard other players saying the same. So I created a plugin that would make it easier for them to destroy the Korath drones so they wouldn't have to bomb Zenith.