### PR TITLE
Add Prism.yaml

### DIFF
--- a/manifests/Prism.yaml
+++ b/manifests/Prism.yaml
@@ -1,7 +1,7 @@
 name: Prism Plugin
 authors: Startingfresher
 homepage: https://github.com/Startingfresher/Prism-Plug-in
-license: GPL-3.0+
+license: GPL-3.0-or-later
 version: v1.2
 shortDescription: Allows you to change your ship swizzle(colors, sort of) easily in game.
 description: >-

--- a/manifests/Prism.yaml
+++ b/manifests/Prism.yaml
@@ -2,14 +2,14 @@ name: Prism Plugin
 authors: Startingfresher
 homepage: https://github.com/Startingfresher/Prism-Plug-in
 license: GPL-3.0+
-version: v1.0
+version: v1.2
 shortDescription: Allows you to change your ship swizzle(colors, sort of) easily in game.
 description: >-
   The plugin adds missions on every star that let you change your fleet swizzle
   to a few options. When you start the game you get access to two, eventually you
   will find all 6. Look in the about.txt file for spoilers on where to get em. It should
   be mostly lore friendly.
-url: https://github.com/Startingfresher/Prism-Plug-in/archive/refs/tags/v1.0.zip
+url: https://github.com/Startingfresher/Prism-Plug-in/archive/refs/tags/v1.2.zip
 autoupdate:
   type: tag
   url: https://github.com/Startingfresher/Prism-Plug-in/archive/refs/tags/$version.zip

--- a/manifests/Prism.yaml
+++ b/manifests/Prism.yaml
@@ -1,0 +1,15 @@
+name: Prism Plugin
+authors: Startingfresher
+homepage: https://github.com/Startingfresher/Prism-Plug-in
+license: GPL-3.0+
+version: v1.0
+shortDescription: Allows you to change your ship swizzle(colors, sort of) easily in game.
+description: >- 
+  The plugin adds missions on every star that let you change your fleet swizzle 
+  to a few options. When you start the game you get access to two, eventually you 
+  will find all 6. Look in the about.txt file for spoilers on where to get em. It should
+  be mostly lore friendly.
+url: https://github.com/Startingfresher/Prism-Plug-in/archive/refs/tags/v1.0.zip
+autoupdate:
+  type: tag
+  url: https://github.com/Startingfresher/Prism-Plug-in/archive/refs/tags/$version.zip

--- a/manifests/Prism.yaml
+++ b/manifests/Prism.yaml
@@ -4,9 +4,9 @@ homepage: https://github.com/Startingfresher/Prism-Plug-in
 license: GPL-3.0+
 version: v1.0
 shortDescription: Allows you to change your ship swizzle(colors, sort of) easily in game.
-description: >- 
-  The plugin adds missions on every star that let you change your fleet swizzle 
-  to a few options. When you start the game you get access to two, eventually you 
+description: >-
+  The plugin adds missions on every star that let you change your fleet swizzle
+  to a few options. When you start the game you get access to two, eventually you
   will find all 6. Look in the about.txt file for spoilers on where to get em. It should
   be mostly lore friendly.
 url: https://github.com/Startingfresher/Prism-Plug-in/archive/refs/tags/v1.0.zip


### PR DESCRIPTION
I wrote my first plugin, yay! anyways, what it does is create 6 new repeating missions that become offered when gaining certain licenses (to purchase ships) that allow you to switch your fleet swizzle to a new option if you have a positive relationship with the requisite government. that last part is to make it story friendly, somewhat*, with the FW campaign because you cant change to merchant colors when the republic(or the other main human governments) are hostile

*you can still sneak it in during a ceasefire, but this plugin is meant to be a fun side thing, not a fool proof solution. I decided to keep the requirements despite the wonky-ness because it adds some mediocrum of gameplay, having access to all the colors at any time is something you can do on your own by altering your governments.txt file.

The about.txt file in the repository has a description of which licences you need for what.
I'm fairly sure I got the copyright stuff all good, but a critical eye probably wouldn't hurt.