### PR TITLE
Add Ruin-The-Fun

### DIFF
--- a/manifests/es-ruin-the-fun.yaml
+++ b/manifests/es-ruin-the-fun.yaml
@@ -2,7 +2,7 @@ name: Ruin The Fun
 authors: Pshy
 homepage: https://github.com/pshy0/es-ruin-the-fun
 license: ISC
-version: v0.0.1
+version: v0.0.4
 shortDescription: Cheat plugin to help development of other plugins.
 description: Ruin-The-Fun (CHEAT PLUGIN)
   The gods acknowledged your immensity, and are now serving you.
@@ -10,8 +10,8 @@ description: Ruin-The-Fun (CHEAT PLUGIN)
   All ships and outfits available, plus OP ones, jobs to get free money, change your swizzle and name, choose your combat rank, get an escort, and more...
   Run `make update` in the plugin's folder to update content from the game data.
   Run `make plugin-update` in the plugin's folder to include content from other enabled plugins.
-url: https://github.com/pshy0/es-ruin-the-fun/archive/refs/tags/v0.0.1.zip
-iconUrl: https://github.com/pshy0/es-ruin-the-fun/raw/v0.0.1/icon.png
+url: https://github.com/pshy0/es-ruin-the-fun/archive/refs/tags/v0.0.4.zip
+iconUrl: https://github.com/pshy0/es-ruin-the-fun/raw/v0.0.4/icon.png
 autoupdate:
   type: tag
   url: https://github.com/pshy0/es-ruin-the-fun/archive/refs/tags/$version.zip

--- a/manifests/es-ruin-the-fun.yaml
+++ b/manifests/es-ruin-the-fun.yaml
@@ -1,7 +1,7 @@
 name: Ruin The Fun
 authors: Pshy
 homepage: https://github.com/pshy0/es-ruin-the-fun
-license: TFCL
+license: ISC
 version: v0.0.1
 shortDescription: Cheat plugin to help development of other plugins.
 description: Ruin-The-Fun (CHEAT PLUGIN)

--- a/manifests/es-ruin-the-fun.yaml
+++ b/manifests/es-ruin-the-fun.yaml
@@ -16,4 +16,3 @@ autoupdate:
   type: tag
   url: https://github.com/pshy0/es-ruin-the-fun/archive/refs/tags/$version.zip
   iconUrl: https://github.com/pshy0/es-ruin-the-fun/raw/$version/icon.png
-

--- a/manifests/es-ruin-the-fun.yaml
+++ b/manifests/es-ruin-the-fun.yaml
@@ -1,0 +1,19 @@
+name: Ruin The Fun
+authors: Pshy
+homepage: https://github.com/pshy0/es-ruin-the-fun
+license: TFCL
+version: v0.0.1
+shortDescription: Cheat plugin to help development of other plugins.
+description: Ruin-The-Fun (CHEAT PLUGIN)
+  The gods acknowledged your immensity, and are now serving you.
+  This plugin's features are available from the `RTF` systems. The most obvious one is located under `Rutilicus`.
+  All ships and outfits available, plus OP ones, jobs to change your swizzle, trigger events, reset your reputation, get an escort, and more...
+  Run `make update` in the plugin's folder to update content from the game data.
+  Run `make plugin-update` in the plugin's folder to include content from other enabled plugins.
+url: https://github.com/pshy0/es-ruin-the-fun/archive/refs/tags/v0.0.1.zip
+iconUrl: https://github.com/pshy0/es-ruin-the-fun/raw/v0.0.1/icon.png
+autoupdate:
+  type: tag
+  url: https://github.com/pshy0/es-ruin-the-fun/archive/refs/tags/$version.zip
+  iconUrl: https://github.com/pshy0/es-ruin-the-fun/raw/$version/icon.png
+

--- a/manifests/es-ruin-the-fun.yaml
+++ b/manifests/es-ruin-the-fun.yaml
@@ -7,7 +7,7 @@ shortDescription: Cheat plugin to help development of other plugins.
 description: Ruin-The-Fun (CHEAT PLUGIN)
   The gods acknowledged your immensity, and are now serving you.
   This plugin's features are available from the `RTF` systems. The most obvious one is located under `Rutilicus`.
-  All ships and outfits available, plus OP ones, jobs to change your swizzle, trigger events, reset your reputation, get an escort, and more...
+  All ships and outfits available, plus OP ones, jobs to get free money, change your swizzle and name, choose your combat rank, get an escort, and more...
   Run `make update` in the plugin's folder to update content from the game data.
   Run `make plugin-update` in the plugin's folder to include content from other enabled plugins.
 url: https://github.com/pshy0/es-ruin-the-fun/archive/refs/tags/v0.0.1.zip


### PR DESCRIPTION
Another cheat / development plugin.

This one have a Makefile with rules to update the plugin's content, so you do not have to wait for the next update of the plugin to access newly added vanilla items. It can also optionally include content from other enabled plugins.

> Ruin-The-Fun (CHEAT PLUGIN)
>   The gods acknowledged your immensity, and are now serving you.
>   This plugin's features are available from the `RTF` systems. The most obvious one is located under `Rutilicus`.
>   All ships and outfits available, plus OP ones, jobs to change your swizzle, trigger events, reset your reputation, get an escort, and more...