### PR TITLE
Change Naming Scheme for A Coalition at War

### DIFF
--- a/manifests/A Coalition at War.yaml
+++ b/manifests/A Coalition at War.yaml
@@ -2,7 +2,7 @@ name: A Coalition at War
 authors: Josh Mudge
 homepage: https://github.com/mathwhiz1212/A-Coalition-At-War
 license: GPL-3.0-or-later
-version: v0.10.4a
+version: v0.10.4.1.0
 shortDescription: Pick a side in the war between the Coalition and Quarg. I am looking
   for story and mission suggestions https://github.com/mathwhiz1212/A-Coalition-At-War/
 description: You hear a lot about the conflict between the Coalition and the Quarg
@@ -11,7 +11,7 @@ description: You hear a lot about the conflict between the Coalition and the Qua
   depending on the side you choose. You can start the few implemented missions by
   landing on "Tebuteb's Table" in the Tebuteb system and accept the anamoly mission.
   Please consider helping to add more misisons and stories https://github.com/mathwhiz1212/A-Coalition-At-War/issues/new/choose
-url: https://github.com/mathwhiz1212/A-Coalition-At-War/archive/refs/tags/v0.10.4a.zip
+url: https://github.com/mathwhiz1212/A-Coalition-At-War/archive/refs/tags/v0.10.4.1.0.zip
 autoupdate:
   type: tag
   url: https://github.com/mathwhiz1212/A-Coalition-At-War/archive/refs/tags/$version.zip


### PR DESCRIPTION
I changed the naming scheme for versions on A Coalition at War. This pull request should allow auto-update to work again.