### PR TITLE
Make the Jibauni use their continuous version

### DIFF
--- a/manifests/Jibauni.yaml
+++ b/manifests/Jibauni.yaml
@@ -2,14 +2,13 @@ name: Jibauni
 authors: TheGiraffe3
 homepage: https://github.com/TheGiraffe3/Jibauni
 license: CC-BY-SA-4.0
-version: v0.6
+version: 21d6ec43f5a3db058fbda1b036e47a5b2ede0652
 shortDescription: Adds three new alien species.
 description: Adds the Jibauni, Diba, and re-adds the Sheragi. The Jibauni are dinosaurs,
   the Diba are robots, and the Sheragi are dragons.
-url: https://github.com/TheGiraffe3/Jibauni/archive/refs/tags/v0.6.zip
-iconUrl: https://raw.githubusercontent.com/TheGiraffe3/Jibauni/v0.6/icon.png
+url: https://github.com/TheGiraffe3/Jibauni/archive/21d6ec43f5a3db058fbda1b036e47a5b2ede0652.zip
+iconUrl: https://raw.githubusercontent.com/TheGiraffe3/Jibauni/21d6ec43f5a3db058fbda1b036e47a5b2ede0652/icon.png
 autoupdate:
-  type: tag
-  branch: Jibauni
+  type: commit
   url: https://github.com/TheGiraffe3/Jibauni/archive/refs/tags/$version.zip
   iconUrl: https://raw.githubusercontent.com/TheGiraffe3/Jibauni/$version/icon.png

--- a/manifests/Jibauni.yaml
+++ b/manifests/Jibauni.yaml
@@ -10,5 +10,5 @@ url: https://github.com/TheGiraffe3/Jibauni/archive/21d6ec43f5a3db058fbda1b036e4
 iconUrl: https://raw.githubusercontent.com/TheGiraffe3/Jibauni/21d6ec43f5a3db058fbda1b036e47a5b2ede0652/icon.png
 autoupdate:
   type: commit
-  url: https://github.com/TheGiraffe3/Jibauni/archive/refs/tags/$version.zip
+  url: https://github.com/TheGiraffe3/Jibauni/archive/$version.zip
   iconUrl: https://raw.githubusercontent.com/TheGiraffe3/Jibauni/$version/icon.png


### PR DESCRIPTION
(I hope I did this right)

Makes the Jibauni so that it uses the continuous version of the plugin instead of a tag.