### PR TITLE
[fix] 'Disable Free Worlds' version string

### DIFF
--- a/manifests/Disable Free Worlds.yaml
+++ b/manifests/Disable Free Worlds.yaml
@@ -2,7 +2,7 @@ name: Disable Free Worlds
 authors: ziproot
 homepage: https://github.com/ziproot/disable-free-worlds
 license: CC0-1.0
-version: 1.0
+version: '1.0'
 shortDescription: Exactly what it says on the tin. Disables all events related to the main plot, along with the Pact Recon mission chain.
 description: Exactly what it says on the tin. Disables all events related to the main plot, along with the Pact Recon mission chain.
 url: https://github.com/ziproot/disable-free-worlds/archive/3dd174e3391fb00c44f4cc2f12149de709f95c5c.zip


### PR DESCRIPTION
Plugin's version is interpreted as integer, which breaks [ESLauncher2](https://github.com/EndlessSkyCommunity/ESLauncher2) plugin functionality:
```
[ERROR] Failed to initialize ESPIM, Plug-Ins will be unavailable: Failed to read JSON: invalid type: integer `1`, expected a string at line 24 column 17
```
ESPIM expects string [here](https://github.com/EndlessSkyCommunity/espim/blob/master/src/lib.rs#L39):
```rust
struct AvailablePlugin {
    ...
    version: String,
    ...
}
```

Added single quotes, like in [Endless Sky Starbridge Pack.yaml](https://github.com/endless-sky/endless-sky-plugins/blob/master/manifests/Endless%20Sky%20Starbridge%20Pack.yaml#L5).