### PR TITLE
Make Rumskib use releases instead of commits

### DIFF
--- a/manifests/Rumskib.yaml
+++ b/manifests/Rumskib.yaml
@@ -2,16 +2,14 @@ name: Rumskib
 authors: TheGiraffe3
 homepage: https://github.com/TheGiraffe3/rumskib/
 license: CC-BY-SA-4.0
-version: 21fddd92e7e3e63ade2f0cf394666ab68655fda3
+version: v1.0.3
 shortDescription: Adds more ships.
 description: Adds the Cutlass, which is a piratified Gunboat, and the Tanager, which
-  is a better version of the Shuttle. Also extends the Hauler and Hauler (Type F)
-  lines with the Hauler IV and Eyrie designs.
-url: https://github.com/TheGiraffe3/rumskib/archive/21fddd92e7e3e63ade2f0cf394666ab68655fda3.zip
-iconUrl: https://github.com/TheGiraffe3/rumskib/raw/745ca479f5b10ece40dc766753adf43abe3df24f/icon.png
+  is a better version of the Shuttle. Also adds the Cleaver, an improved Sunder
+  made by a different company.
+url: https://github.com/TheGiraffe3/rumskib/archive/refs/tags/v1.0.3.zip
+iconUrl: https://github.com/TheGiraffe3/rumskib/raw/v1.0.3/icon.png
 autoupdate:
-  type: commit
-  branch: main
-  url: https://github.com/TheGiraffe3/rumskib/archive/$version.zip
-  iconURL: https://github.com/TheGiraffe3/rumskib/raw/$version/icon.png
-iconURL: https://github.com/TheGiraffe3/rumskib/raw/21fddd92e7e3e63ade2f0cf394666ab68655fda3/icon.png
+  type: tag
+  url: https://github.com/TheGiraffe3/rumskib/archive/refs/heads/$version.zip
+  iconUrl: https://github.com/TheGiraffe3/rumskib/raw/$version/icon.png

--- a/manifests/Rumskib.yaml
+++ b/manifests/Rumskib.yaml
@@ -11,5 +11,5 @@ url: https://github.com/TheGiraffe3/rumskib/archive/refs/tags/v1.0.3.zip
 iconUrl: https://github.com/TheGiraffe3/rumskib/raw/v1.0.3/icon.png
 autoupdate:
   type: tag
-  url: https://github.com/TheGiraffe3/rumskib/archive/refs/heads/$version.zip
+  url: https://github.com/TheGiraffe3/rumskib/archive/refs/tags/$version.zip
   iconUrl: https://github.com/TheGiraffe3/rumskib/raw/$version/icon.png


### PR DESCRIPTION
I'm sorry about all the PRs you've had to merge recently. This should go a ways to help with that.