### PR TITLE
Add Endless Music (Egg Edition)

### DIFF
--- a/manifests/endlessmusic.yaml
+++ b/manifests/endlessmusic.yaml
@@ -1,0 +1,12 @@
+name: Endless Music (Egg Edition)
+authors: ziproot et al.
+homepage: https://git.nixnet.services/ziproot/endless-music-egg-edition
+license: GPL-3+
+version: 2.0.1
+shortDescription: Adds 30 CC-BY/CC-BY-SA/GPL songs made by various artists that play in various conditions.
+description: This plugin adds 30 songs to the game that play in various conditions. I did not make these songs, and they are credited and sourced in the copyright file. Hopefully this will inspire improvements to the antequated music system. Note: No music will play with a new pilot using one of the vanilla starts. Music is unlocked as you progress through the game. Some plugin starts may skip you ahead, which would result in some songs playing. Main Plot Plus and Crisis in Management are supported. No other plugins are officially supported, though plugins that do not add new systems or story content, like Blended Ships, No More Inflation, or LinearHPScaling, should be supported.
+url: https://git.nixnet.services/ziproot/endless-music-egg-edition/archive/2.0.1.zip
+iconUrl: https://git.nixnet.services/ziproot/endless-music-egg-edition/raw/branch/main/icon.png
+autoupdate:
+  type: tag
+  url: https://git.nixnet.services/ziproot/endless-music-egg-edition/archive/$version.zip

--- a/manifests/endlessmusic.yaml
+++ b/manifests/endlessmusic.yaml
@@ -1,7 +1,7 @@
 name: Endless Music (Egg Edition)
 authors: ziproot et al.
 homepage: https://git.nixnet.services/ziproot/endless-music-egg-edition
-license: GPL-3+
+license: GPL-3.0-or-later
 version: 2.0.1
 shortDescription: Adds 30 CC-BY/CC-BY-SA/GPL songs made by various artists that play in various conditions.
 description: This plugin adds 30 songs to the game that play in various conditions. I did not make these songs, and they are credited and sourced in the copyright file. Hopefully this will inspire improvements to the antequated music system. No music will play with a new pilot using one of the vanilla starts. Music is unlocked as you progress through the game. Some plugin starts may skip you ahead, which would result in some songs playing. Main Plot Plus and Crisis in Management are supported. No other plugins are officially supported, though plugins that do not add new systems or story content, like Blended Ships, No More Inflation, or LinearHPScaling, should be supported.

--- a/manifests/endlessmusic.yaml
+++ b/manifests/endlessmusic.yaml
@@ -4,7 +4,7 @@ homepage: https://git.nixnet.services/ziproot/endless-music-egg-edition
 license: GPL-3+
 version: 2.0.1
 shortDescription: Adds 30 CC-BY/CC-BY-SA/GPL songs made by various artists that play in various conditions.
-description: This plugin adds 30 songs to the game that play in various conditions. I did not make these songs, and they are credited and sourced in the copyright file. Hopefully this will inspire improvements to the antequated music system. Note: No music will play with a new pilot using one of the vanilla starts. Music is unlocked as you progress through the game. Some plugin starts may skip you ahead, which would result in some songs playing. Main Plot Plus and Crisis in Management are supported. No other plugins are officially supported, though plugins that do not add new systems or story content, like Blended Ships, No More Inflation, or LinearHPScaling, should be supported.
+description: This plugin adds 30 songs to the game that play in various conditions. I did not make these songs, and they are credited and sourced in the copyright file. Hopefully this will inspire improvements to the antequated music system. No music will play with a new pilot using one of the vanilla starts. Music is unlocked as you progress through the game. Some plugin starts may skip you ahead, which would result in some songs playing. Main Plot Plus and Crisis in Management are supported. No other plugins are officially supported, though plugins that do not add new systems or story content, like Blended Ships, No More Inflation, or LinearHPScaling, should be supported.
 url: https://git.nixnet.services/ziproot/endless-music-egg-edition/archive/2.0.1.zip
 iconUrl: https://git.nixnet.services/ziproot/endless-music-egg-edition/raw/branch/main/icon.png
 autoupdate:


### PR DESCRIPTION
This plugin adds 30 songs to the game that play in various conditions. I did not make these songs, and they are credited and sourced in the copyright file. Hopefully this will inspire improvements to the antequated music system.

Note: No music will play with a new pilot using one of the vanilla starts. Music is unlocked as you progress through the game.Some plugin starts may skip you ahead, which would result in some songs playing.

Main Plot Plus and Crisis in Management are supported. No other plugins are officially supported, though plugins that do not add new systems or story content, like Blended Ships, No More Inflation, or LinearHPScaling, should be supported.
